### PR TITLE
NTA font license clash

### DIFF
--- a/src/public/scss/styles.scss
+++ b/src/public/scss/styles.scss
@@ -1,3 +1,5 @@
+$govuk-font-family: Arial, sans-serif;
+
 @import "../../../node_modules/govuk-frontend/all";
 @import "utilities";
 @import "../../app/components/render-collection/render-collection";


### PR DESCRIPTION
remove NTA font from the allowed gov font family
