### PR TITLE
Feature/turn off caching for dev

### DIFF
--- a/src/app/lib/get-cache-time.js
+++ b/src/app/lib/get-cache-time.js
@@ -1,15 +1,20 @@
-const fiveMins = (1000 * 60 * 5)
-
 module.exports = function () {
   const date = new Date()
+  const newDate = new Date()
+  let delay
+
   if (date.getHours() < 8) {
-    date.setTime(date.getTime() + fiveMins)
+    delay = 60 * 5
   } else {
-    date.setHours(23, 59, 59, 0)
+    delay = Math.ceil(Math.abs((date.setHours(23, 59, 59, 0) - (newDate.getTime())) / 1000))
+  }
+
+  function getDelayedTime (dt, seconds) {
+    return new Date(dt.getTime() + seconds * 1000)
   }
 
   return {
-    seconds: (date.getTime() / 1000),
-    utc: date.toUTCString(),
+    seconds: delay,
+    utc: getDelayedTime(newDate, delay).toUTCString(),
   }
 }

--- a/src/test/app/specs/lib/get-cache-time.spec.js
+++ b/src/test/app/specs/lib/get-cache-time.spec.js
@@ -12,7 +12,7 @@ describe('getCacheTime', () => {
         it('Should return 5 mins time', () => {
           mockdate.set('Mon, 30 Apr 2018 04:00:01 GMT')
           const time = getCacheTime()
-          expect(time.seconds).toEqual(1525061101)
+          expect(time.seconds).toEqual(300)
           expect(time.utc).toEqual('Mon, 30 Apr 2018 04:05:01 GMT')
         })
       })
@@ -21,7 +21,7 @@ describe('getCacheTime', () => {
         it('Should return 5 mins time', () => {
           mockdate.set('Mon, 30 Apr 2018 05:28:01 GMT')
           const time = getCacheTime()
-          expect(time.seconds).toEqual(1525066381)
+          expect(time.seconds).toEqual(300)
           expect(time.utc).toEqual('Mon, 30 Apr 2018 05:33:01 GMT')
         })
       })
@@ -30,7 +30,7 @@ describe('getCacheTime', () => {
         it('Should return 5 mins time', () => {
           mockdate.set('Mon, 30 Apr 2018 06:59:00 GMT')
           const time = getCacheTime()
-          expect(time.seconds).toEqual(1525071840)
+          expect(time.seconds).toEqual(300)
           expect(time.utc).toEqual('Mon, 30 Apr 2018 07:04:00 GMT')
         })
       })
@@ -42,7 +42,7 @@ describe('getCacheTime', () => {
           mockdate.set('Mon, 30 Apr 2018 7:59:00 GMT')
           const time = getCacheTime()
 
-          expect(time.seconds).toEqual(1525129199)
+          expect(time.seconds).toEqual(54059)
           expect(time.utc).toEqual('Mon, 30 Apr 2018 22:59:59 GMT')
         })
       })
@@ -52,7 +52,7 @@ describe('getCacheTime', () => {
           mockdate.set('Mon, 30 Apr 2018 08:01:01 GMT')
           const time = getCacheTime()
 
-          expect(time.seconds).toEqual(1525129199)
+          expect(time.seconds).toEqual(53938)
           expect(time.utc).toEqual('Mon, 30 Apr 2018 22:59:59 GMT')
         })
       })
@@ -62,7 +62,7 @@ describe('getCacheTime', () => {
           mockdate.set('Mon, 30 Apr 2018 11:00:01 GMT')
           const time = getCacheTime()
 
-          expect(time.seconds).toEqual(1525129199)
+          expect(time.seconds).toEqual(43198)
           expect(time.utc).toEqual('Mon, 30 Apr 2018 22:59:59 GMT')
         })
       })
@@ -75,7 +75,7 @@ describe('getCacheTime', () => {
         it('Should return 5 mins time', () => {
           mockdate.set('Tue, 02 Jan 2018 07:59:00 GMT')
           const time = getCacheTime()
-          expect(time.seconds).toEqual(1514880240)
+          expect(time.seconds).toEqual(300)
           expect(time.utc).toEqual('Tue, 02 Jan 2018 08:04:00 GMT')
         })
       })
@@ -87,7 +87,7 @@ describe('getCacheTime', () => {
           mockdate.set('Tue, 02 Jan 2018 08:01:01 GMT')
           const time = getCacheTime()
 
-          expect(time.seconds).toEqual(1514937599)
+          expect(time.seconds).toEqual(57538)
           expect(time.utc).toEqual('Tue, 02 Jan 2018 23:59:59 GMT')
         })
       })


### PR DESCRIPTION
Redis cache expiration date was using epoch reference - meaning seconds since 1st Jan 1970, and was causing the caching to never expire. change the logic so it uses smaller integers corresponding to the number of seconds in 5 minutes, during the night or equivalent to the seconds from the number of hours till midnight.
