### PR TITLE
FEX-80 Add the ability to filter by postcode on the frontend

### DIFF
--- a/src/app/builders.js
+++ b/src/app/builders.js
@@ -9,6 +9,7 @@ const {
   transformQueryToSortFilter,
   transformQueryToTurnoverFilter,
   transformToLowerTrimStart,
+  transformCommaSeparatedStringToArray,
 } = require('./transformers')
 
 function buildHeader (req, res, next) {
@@ -53,12 +54,12 @@ async function buildFilters (req, res, next) {
       ...sanitizeKeyValuePair('dit_sectors', req.query['dit-sectors'], castArray),
       ...sanitizeKeyValuePair('service_usage', req.query['service-used'], castArray),
       ...sanitizeKeyValuePair('region', req.query['uk-regions'], castArray),
+      ...sanitizeKeyValuePair('postcode', req.query.postcode, transformCommaSeparatedStringToArray),
     },
     sort: {
       ...transformQueryToSortFilter(req.query.sort),
     },
   }
-
   next()
 }
 

--- a/src/app/components/filter-postcode/macro.njk
+++ b/src/app/components/filter-postcode/macro.njk
@@ -1,0 +1,3 @@
+{% macro filterPostcode(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/src/app/components/filter-postcode/template.njk
+++ b/src/app/components/filter-postcode/template.njk
@@ -1,0 +1,13 @@
+{% from "input/macro.njk" import govukInput %}
+
+<div class="govuk-form-group app-filter-group-heading">
+    {{ govukInput({
+        label: {
+            text: "Postcode",
+            classes: "govuk-!-font-weight-bold app-filter-label"
+        },
+        id: "postcode",
+        name: "postcode",
+        value: params.postcode
+    }) }}
+</div>

--- a/src/app/components/render-collection/template.njk
+++ b/src/app/components/render-collection/template.njk
@@ -36,7 +36,7 @@
                                 {% endfor %}
                             </span>
                         </div>
-                    {% elseif key == 'companyName' or key == 'commodityCode' or key == 'sicCodes'%}
+                    {% elseif key == 'companyName' or key == 'commodityCode' or key == 'sicCodes' or key == 'postcode' %}
                         {% if value %}
                             <div class="app-filters-tags-title-value">
                                 <span class="app-filters-tags-title">{{ key | lowerCase | startCase }}:</span>

--- a/src/app/controllers/acs.js
+++ b/src/app/controllers/acs.js
@@ -46,6 +46,13 @@ async function renderIndex (req, res) {
 
   const sort = req.query.sort || config.defaultSortValue
 
+  // Use the cleaned version of the postcode query to show on the frontend
+  const postcode = res.locals.query &&
+    res.locals.query.filters &&
+    res.locals.query.filters.postcode &&
+    res.locals.query.filters.postcode.length &&
+    res.locals.query.filters.postcode.join(', ')
+
   return res.render('index', {
     result: data,
     globalHeader,
@@ -61,6 +68,7 @@ async function renderIndex (req, res) {
       sectors,
       serviceUsed,
       ukRegions,
+      postcode,
     },
     sort,
   })

--- a/src/app/repos.js
+++ b/src/app/repos.js
@@ -15,7 +15,6 @@ async function getData (req, res, query = {}) {
     const page = req.query.page || 1
     const offset = transformPageToOffset(page)
     const query = isEmpty(res.locals.query.filters) ? { sort: res.locals.query.sort } : res.locals.query
-
     return await backendService.searchForCompanies(offset, config.paginationOffset, query)
   } catch (err) {
     logger.error(err)

--- a/src/app/transformers.js
+++ b/src/app/transformers.js
@@ -139,6 +139,19 @@ function transformStringToOptionUnformatted (string) {
   }
 }
 
+/**
+ * transformCommaSeparatedStringToArray
+ * Will split string on commas to an array, trim whitespace off each resulting
+ * element, and finally filter out any empty string elements.
+ */
+
+function transformCommaSeparatedStringToArray (string) {
+  const arr = string.split(',')
+  const trimmed = arr.map(s => s.trim())
+  const emptyRemoved = trimmed.filter(s => s)
+  return emptyRemoved
+}
+
 module.exports = {
   selectCheckboxFilter,
   sanitizeKeyValuePair,
@@ -149,5 +162,6 @@ module.exports = {
   transformQueryToTurnoverFilter,
   transformStringToOption,
   transformStringToOptionUnformatted,
+  transformCommaSeparatedStringToArray,
   transformToLowerTrimStart,
 }

--- a/src/app/views/index.njk
+++ b/src/app/views/index.njk
@@ -9,6 +9,7 @@
 {% from "filter-market-exported-to/macro.njk" import filterMarketExportedTo %}
 {% from "filter-latest-export-evidence/macro.njk" import filterLatestExportEvidence %}
 {% from "filter-sectors/macro.njk" import filterSectors %}
+{% from "filter-postcode/macro.njk" import filterPostcode %}
 {% from "render-collection/macro.njk" import renderCollection %}
 {% from "input/macro.njk" import govukInput %}
 {% from "local-phase-banner/macro.njk" import localPhaseBanner %}
@@ -32,6 +33,7 @@
                 {{ filterSicCodes(filters) }}
                 {{ filterTurnover(filters) }}
                 {{ filterSectors(filters) }}
+                {{ filterPostcode(filters) }}
                 {{ filterUkRegions(filters) }}
                 {{ filterMarketOfInterest(filters) }}
                 {{ filterMarketExportedTo(filters) }}

--- a/src/test/app/specs/builders.spec.js
+++ b/src/test/app/specs/builders.spec.js
@@ -1,0 +1,34 @@
+const {
+  buildFilters,
+} = require('../../../app/builders')
+
+describe('buildFilters', () => {
+  let req
+  let res
+  let next
+
+  beforeEach(() => {
+    req = { query: {} }
+    res = {
+      setHeader: jest.fn(),
+      locals: {},
+    }
+    next = jest.fn()
+  })
+  it('Transforms the postcode filter correctly', async () => {
+    req.query = { postcode: 'w1, w2, w3' }
+    await buildFilters(req, res, next)
+    expect(res.locals.query.filters.postcode).toEqual(['w1', 'w2', 'w3'])
+  })
+  it('Handles request with no query', async () => {
+    await buildFilters(req, res, next)
+    expect(res.locals.query.filters).toEqual({})
+  })
+  const emptyCases = ['', ' ', ',', ',,', ', ', ', ,', ' ,', ' , ', ' , , ,, , ']
+  emptyCases.forEach(emptyCase => {
+    it('Cleans invalid postcode searches', async () => {
+      await buildFilters(req, res, next)
+      expect(res.locals.query.filters).toEqual({})
+    })
+  })
+})


### PR DESCRIPTION
* Front-end consists of a standard free text input
* Back-end splits the input text on commas, trims off whitespace, chucks
out empty strings
* This cleaned version of the query is used for the display of the
filter at the top of the list

<!--- Add Jira ticket number this work relates to at the beginning of the Title -->
