### PR TITLE
FEX-80 Normalize postcode case and remove duplicates

### DIFF
--- a/src/app/builders.js
+++ b/src/app/builders.js
@@ -9,7 +9,7 @@ const {
   transformQueryToSortFilter,
   transformQueryToTurnoverFilter,
   transformToLowerTrimStart,
-  transformCommaSeparatedStringToArray,
+  transformPostcodeFilter,
 } = require('./transformers')
 
 function buildHeader (req, res, next) {
@@ -54,7 +54,7 @@ async function buildFilters (req, res, next) {
       ...sanitizeKeyValuePair('dit_sectors', req.query['dit-sectors'], castArray),
       ...sanitizeKeyValuePair('service_usage', req.query['service-used'], castArray),
       ...sanitizeKeyValuePair('region', req.query['uk-regions'], castArray),
-      ...sanitizeKeyValuePair('postcode', req.query.postcode, transformCommaSeparatedStringToArray),
+      ...sanitizeKeyValuePair('postcode', req.query.postcode, transformPostcodeFilter),
     },
     sort: {
       ...transformQueryToSortFilter(req.query.sort),

--- a/src/app/transformers.js
+++ b/src/app/transformers.js
@@ -140,16 +140,16 @@ function transformStringToOptionUnformatted (string) {
 }
 
 /**
- * transformCommaSeparatedStringToArray
+ * transformPostcodeFilter
  * Will split string on commas to an array, trim whitespace off each resulting
  * element, and finally filter out any empty string elements.
  */
 
-function transformCommaSeparatedStringToArray (string) {
+function transformPostcodeFilter (string) {
   const arr = string.split(',')
-  const trimmed = arr.map(s => s.trim())
-  const emptyRemoved = trimmed.filter(s => s)
-  return emptyRemoved
+  const normalized = arr.map(s => s.trim().toUpperCase())
+  const emptyRemoved = normalized.filter(s => s)
+  return [...new Set(emptyRemoved)]
 }
 
 module.exports = {
@@ -162,6 +162,6 @@ module.exports = {
   transformQueryToTurnoverFilter,
   transformStringToOption,
   transformStringToOptionUnformatted,
-  transformCommaSeparatedStringToArray,
+  transformPostcodeFilter,
   transformToLowerTrimStart,
 }

--- a/src/test/app/specs/builders.spec.js
+++ b/src/test/app/specs/builders.spec.js
@@ -18,7 +18,12 @@ describe('buildFilters', () => {
   it('Transforms the postcode filter correctly', async () => {
     req.query = { postcode: 'w1, w2, w3' }
     await buildFilters(req, res, next)
-    expect(res.locals.query.filters.postcode).toEqual(['w1', 'w2', 'w3'])
+    expect(res.locals.query.filters.postcode).toEqual(['W1', 'W2', 'W3'])
+  })
+  it('Combines cases and removes duplicates', async () => {
+    req.query = { postcode: 'w1, w1, w2, W2, abc, abC, aBc, aBC, Abc, AbC, ABc, ABC' }
+    await buildFilters(req, res, next)
+    expect(res.locals.query.filters.postcode).toEqual(['W1', 'W2', 'ABC'])
   })
   it('Handles request with no query', async () => {
     await buildFilters(req, res, next)


### PR DESCRIPTION
* Change to this feature so that postcodes are all normalised to uppercase, and then duplicates removed before sending on to backend.
