### PR TITLE
FEX-107 Add dissolved company notice on results page

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -70,6 +70,7 @@ let config = {
   },
   paginationMaxResults: 10000,
   paginationOffset: 20,
+  daysUntilDissolvedCompaniesDeleted: 180,
   defaultSortValue: 'export_propensity:desc',
   redis: {
     host: env('REDIS_HOST'),

--- a/src/app/components/render-collection/template.njk
+++ b/src/app/components/render-collection/template.njk
@@ -136,6 +136,17 @@
                             {% else %}
                                 <h3 class="govuk-heading-m govuk-!-margin-top-4"><a href="/company-profile/{{ item.company_id }}">{{ item.company_name | title }}</a></h3>
                             {% endif %}
+                            {% if item.time_since_remove_recorded %}
+                                <p>
+                                    <strong>
+                                        This company dissolved on {{ item.dissolved_date }} and will be deleted
+                                    {% if item.days_to_deletion < 2 %}
+                                        soon.
+                                    {% else %}
+                                        in {{ item.days_to_deletion }} days.
+                                    {% endif %}
+                                </strong></p>
+                            {% endif %}
                             </div>
                             {% if item.region %}
                                 <div class="govuk-grid-column-one-third">

--- a/src/app/controllers/acs.js
+++ b/src/app/controllers/acs.js
@@ -1,5 +1,6 @@
 const config = require('../../../config')
 const { buildPagination } = require('../lib/pagination')
+const prepareCompany = require('../transformers').prepareCompany
 
 const {
   getCheckboxFilter,
@@ -8,8 +9,9 @@ const {
 
 function getIndexData (req, res) {
   return getData(req, res, req.body).then((response) => {
-    const result = response.body.result || {}
+    const rawResult = response.body.result || []
     const count = response.body.count || 0
+    const result = rawResult.map(prepareCompany)
 
     return {
       ...response,

--- a/src/test/app/specs/controllers/acs.spec.js
+++ b/src/test/app/specs/controllers/acs.spec.js
@@ -3,3 +3,79 @@ xdescribe('The ACS controller', () => {
     expect('ACS').toEqual('ACS')
   })
 })
+const repos = require('../../../../app/repos')
+
+const renderIndex = require('../../../../app/controllers/acs.js').renderIndex
+
+jest.mock('../../../../app/repos', () => ({
+  getCheckboxFilter: jest.fn(),
+  getData: jest.fn(),
+}))
+
+describe('renderIndex', () => {
+  let req
+  let res
+  let next
+  let dateNowSpy
+  beforeEach(() => {
+    req = { query: {} }
+    res = {
+      setHeader: jest.fn(),
+      render: jest.fn(),
+      locals: { globalHeader: '', query: null },
+    }
+    next = jest.fn()
+    const staticDate = new Date('2019-01-01 13:00:00Z')
+    dateNowSpy = jest.spyOn(Date, 'now').mockImplementation(() => staticDate)
+  })
+  afterEach(() => {
+    dateNowSpy.mockRestore()
+  })
+  describe('Logic for dissolved Companies', () => {
+    for (let [timeSinceRemoveRecorded, dissolvedDate, daysToDeletion] of [
+      ['2019-01-01T00:00:00', '01/01/2019', 180],
+      ['2018-12-31T23:59:59', '31/12/2018', 179],
+      ['1901-01-01T00:00:00', '01/01/1901', -42919],
+      ['2049-05-30T00:00:00', '30/05/2049', 11287],
+      ['2019-06-30T00:00:00', '30/06/2019', 360],
+      ['2018-07-05T00:00:00', '05/07/2018', 0],
+    ]) {
+      it(`Has correct logic for ${timeSinceRemoveRecorded}`, (done) => {
+        repos.getData.mockReturnValueOnce(Promise.resolve({
+          body: {
+            result: [{
+              time_since_remove_recorded: timeSinceRemoveRecorded,
+            }],
+          },
+        }))
+        renderIndex(req, res, next).then(() => {
+          expect(res.render.mock.calls.length).toBe(1)
+          const renderContext = res.render.mock.calls[0][1]
+          expect(renderContext.result.result[0].time_since_remove_recorded).toBe(timeSinceRemoveRecorded)
+          expect(renderContext.result.result[0].dissolved_date).toBe(dissolvedDate)
+          expect(renderContext.result.result[0].days_to_deletion).toBe(daysToDeletion)
+          done()
+        })
+      })
+    }
+    for (let garbageDate of ['', undefined, null, '2019-02-29T00:00:00', 'asdfasdf']) {
+      it(`Doesn't choke on date ${garbageDate}`, () => {
+        repos.getData.mockReturnValueOnce(Promise.resolve({
+          body: {
+            result: [{
+              time_since_remove_recorded: garbageDate,
+            }],
+          },
+        }))
+        renderIndex(req, res, next).then(() => {
+          expect(res.render.mock.calls.length).toBe(1)
+          const renderContext = res.render.mock.calls[0][1]
+          expect(renderContext.result.result[0].time_since_remove_recorded).toBe(null)
+          expect(renderContext.result.result[0].dissolved_date).toBe(null)
+          expect(renderContext.result.result[0].days_to_deletion).toBe(null)
+          done()
+        })
+      })
+    }
+  })
+})


### PR DESCRIPTION
A new function prepareCompany was added to transformers.js.
This contains the logic required to prepare the dissolved company
notice for the nunjucks template. In future, any additional logic
required to transform the company result as returned by dt07
can be added to this function.

New config item daysUntilDissolvedCompaniesDeleted was added and set to
180.

<!--- Add Jira ticket number this work relates to at the beginning of the Title -->
