### PR TITLE
FEX-156 Remove whitespace from postcode query

### DIFF
--- a/src/app/transformers.js
+++ b/src/app/transformers.js
@@ -22,7 +22,8 @@ function selectCheckboxFilter (query, filter) {
 
 function sanitizeKeyValuePair (key, value = '', utility = {}) {
   if (isFunction(utility)) {
-    return (value.length && { [key]: utility(value) })
+    const transformedValue = utility(value)
+    return (value.length && transformedValue.length && { [key]: utility(value) })
   } else {
     return (value.length && { [key]: value })
   }
@@ -140,7 +141,7 @@ function transformStringToOption (string) {
 
 function transformPostcodeFilter (string) {
   const arr = string.split(',')
-  const normalized = arr.map(s => s.trim().toUpperCase())
+  const normalized = arr.map(s => s.replace(/\s/g, '').toUpperCase())
   const emptyRemoved = normalized.filter(s => s)
   return [...new Set(emptyRemoved)]
 }

--- a/src/test/app/specs/builders.spec.js
+++ b/src/test/app/specs/builders.spec.js
@@ -32,8 +32,14 @@ describe('buildFilters', () => {
   const emptyCases = ['', ' ', ',', ',,', ', ', ', ,', ' ,', ' , ', ' , , ,, , ']
   emptyCases.forEach(emptyCase => {
     it('Cleans invalid postcode searches', async () => {
+      req.query = { postcode: emptyCase }
       await buildFilters(req, res, next)
       expect(res.locals.query.filters).toEqual({})
     })
+  })
+  it('Removes white space within postcodes', async () => {
+    req.query = { postcode: 'N1 8HJ, AB123 ,  WC  2B    5QH' }
+    await buildFilters(req, res, next)
+    expect(res.locals.query.filters.postcode).toEqual(['N18HJ', 'AB123', 'WC2B5QH'])
   })
 })


### PR DESCRIPTION
The backend (dt07) has recently been changed, fixing bug FEX-156, but also making it more restrictive about acceptable search values. Now only alphanumeric searches are permitted.

This change is to strip out any whitespace from the user's query before sending to the backend.

Users might commonly be tempted to include whitespace if they are searching for a full postcode such as "A1 ABC".

<!--- Add Jira ticket number this work relates to at the beginning of the Title -->
