### PR TITLE
Fix typo on redis conditional config flag

### DIFF
--- a/src/app/middleware/session-store.js
+++ b/src/app/middleware/session-store.js
@@ -7,7 +7,7 @@ module.exports = {
   create: () => {
     let storeObj
 
-    if (config.redis.isCacheEnabled) {
+    if (config.redis.isCachingEnabled) {
       const RedisStore = connectRedis(session)
       storeObj = new RedisStore({
         client: redisClient.get(),


### PR DESCRIPTION
Given the conditional flag was incorrect, redis was never instantiated in store, which meant we had no way of storing SSO credentials causing prod to fail.


Weirdly staging didn't but I suspect it was because it was cached previously?

A new branch will be opened to remove redis logic (currently only used to prevent it from being required during unit tests) and mocking it out instead.