### PR TITLE
Amend GREAT image alt tag to be more descriptive

### DIFF
--- a/src/app/components/render-collection/template.njk
+++ b/src/app/components/render-collection/template.njk
@@ -164,7 +164,7 @@
                                     <div class="govuk-!-display-block govuk-!-padding-top-1 govuk-!-padding-bottom-4">
                                         {% if item.is_joined_find_a_supplier %}
                                             <div class="govuk-!-display-block great-link-with-logo">
-                                                <img src="/public/img/great.svg" alt="GREAT" class="great-logo"/>
+                                                <img src="/public/img/great.svg" alt="GREAT logo" class="great-logo"/>
                                                 {% if item.find_a_supplier_url %}
                                                     <a href="{{ item.find_a_supplier_url }}" target="_blank">
                                                         GREAT Profile (will open in new tab)


### PR DESCRIPTION
Datahub has recently had an accessibility audit, in which they found that some of our alt tags on our images were not descriptive enough. This small PR adds the word 'logo' to the GREAT image tag on the exporter links. This is to make it more obvious to screen readers that this is the GREAT logo, rather than just the word GREAT. 

To test the work, please boot up the branch locally and inspect the GREAT logo on the find exporters home page. You should be able to see that the alt tag now says "GREAT logo" rather than just "GREAT" 


