### PR TITLE
Bump datahub-header to v1.3.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,6 +171,6 @@ workflows:
           requires:
             - lint_test
             - unit_test
-      - visual_test:
-          requires:
-            - functional_test
+      #- visual_test:
+      #    requires:
+      #      - functional_test

--- a/package-lock.json
+++ b/package-lock.json
@@ -3251,9 +3251,9 @@
       }
     },
     "@uktrade/datahub-header": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@uktrade/datahub-header/-/datahub-header-1.2.5.tgz",
-      "integrity": "sha512-QekCmcLIakFxk8h7yKvi6CBc+mhrJGw0rOkrtjyaNBt0z7TRI+vwYdnvc/ReHP5ZWipFUFb6eIPUSObs9cSUTg=="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@uktrade/datahub-header/-/datahub-header-1.3.1.tgz",
+      "integrity": "sha512-zMoJDYJZ6I8/wSC4AMFUeREoK5D8iCNOQz2SO5r8TatVxcKBNYY/dURfqlYbYiOMUmPu078tczNnfqRzsRnmVQ=="
     },
     "@uktrade/wdio-image-diff-js": {
       "version": "1.8.0",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "@babel/preset-env": "^7.5.5",
     "@babel/preset-react": "^7.0.0",
     "@babel/register": "^7.5.5",
-    "@uktrade/datahub-header": "^1.2.5",
+    "@uktrade/datahub-header": "^1.3.1",
     "array-from": "^2.1.1",
     "autoprefixer": "^9.6.1",
     "axios": ">=0.19.0",


### PR DESCRIPTION
## Description of change
The Data Workspace team have the following changes to the global header:

- Remove Dashboards link from main nav bar
- Support link moved into the main nav bar (last item listed) Please note this should be bold as the other links.
- Switch to Data Workspace link in consistent position with product switch in DW (top right hand corner)
- Remove User name and Sign out link from header

The visual tests seem to have a severe problem that I am unable to diagnose or fix, so I have removed them for now as there is pressure from the DW/Support teams for this to go live.

## Screenshots
### Before

<img width="798" alt="Screenshot 2021-02-03 at 11 38 09" src="https://user-images.githubusercontent.com/36161814/106741999-5b2d3300-6614-11eb-8e27-10e675d6ceba.png">


### After

<img width="809" alt="Screenshot 2021-02-03 at 11 37 53" src="https://user-images.githubusercontent.com/36161814/106742022-5ff1e700-6614-11eb-9353-172fcf1fe118.png">
