### PR TITLE
Removed company dissolved message

### DIFF
--- a/src/app/components/render-collection/template.njk
+++ b/src/app/components/render-collection/template.njk
@@ -138,19 +138,6 @@
                                         <a href="/company-profile/{{ item.company_id }}" class="app-company-link">{{ item.company_name | title }}</a>
                                     {% endif %}
                                 </h3>
-                            {% if item.time_since_remove_recorded %}
-                                <p>
-                                    <strong>
-                                        This company dissolved on {{ item.dissolved_date }} and will be deleted
-                                    {% if item.days_to_deletion < 2 %}
-                                        soon.
-                                    {% else %}
-                                        in {{ item.days_to_deletion }} days.
-                                    {% endif %}
-                                </strong></p>
-
-                            {% endif %}
-
                             </div>
                             {% if item.region %}
                                 <div class="govuk-grid-column-one-third">


### PR DESCRIPTION
Since company dissolved data is currently not reliable and in the process of being updated, user decided it makes no sense to keep displaying ambiguous company dissolve message.