### PR TITLE
Upgrade node, yarn and yarn lock file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4566,7 +4566,7 @@
             "glob": "7.1.3",
             "growl": "1.10.5",
             "he": "1.2.0",
-            "js-yaml": "3.13.1",
+            "js-yaml": "^3.13.1",
             "log-symbols": "3.0.0",
             "minimatch": "3.0.4",
             "mkdirp": "0.5.5",
@@ -4589,9 +4589,7 @@
               "dev": true
             },
             "js-yaml": {
-              "version": "3.14.1",
-              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-              "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+              "version": "^3.13.1",
               "dev": true,
               "requires": {
                 "argparse": "^1.0.7",
@@ -8149,9 +8147,7 @@
           }
         },
         "js-yaml": {
-          "version": "3.14.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "version": "^3.13.1",
           "requires": {
             "argparse": "^1.0.7",
             "esprima": "^4.0.0"
@@ -9654,7 +9650,7 @@
         "parseqs": "0.0.6",
         "parseuri": "0.0.6",
         "ws": "~6.1.0",
-        "xmlhttprequest-ssl": "~1.5.4",
+        "xmlhttprequest-ssl": ">=1.6.2",
         "yeast": "0.1.2"
       },
       "dependencies": {
@@ -9674,9 +9670,7 @@
           }
         },
         "xmlhttprequest-ssl": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz",
-          "integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==",
+          "version": ">=1.6.2",
           "dev": true
         }
       }
@@ -9916,7 +9910,7 @@
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "inquirer": "^6.2.2",
-        "js-yaml": "^3.13.0",
+        "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.3.0",
         "lodash": "^4.17.11",
@@ -10024,9 +10018,7 @@
           }
         },
         "js-yaml": {
-          "version": "3.14.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "version": "^3.13.1",
           "dev": true,
           "requires": {
             "argparse": "^1.0.7",
@@ -11535,13 +11527,11 @@
       "integrity": "sha1-91mDufL0E75ljJPf172M5AePXNs=",
       "dev": true,
       "requires": {
-        "js-yaml": "^3.4.6"
+        "js-yaml": "^3.13.1"
       },
       "dependencies": {
         "js-yaml": {
-          "version": "3.14.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "version": "^3.13.1",
           "dev": true,
           "requires": {
             "argparse": "^1.0.7",
@@ -11850,7 +11840,7 @@
             "rc": "^1.2.7",
             "rimraf": "^2.6.1",
             "semver": "^5.3.0",
-            "tar": "^4"
+            "tar": "^4.4.8"
           },
           "dependencies": {
             "chownr": {
@@ -11900,9 +11890,7 @@
               "optional": true
             },
             "tar": {
-              "version": "4.4.17",
-              "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.17.tgz",
-              "integrity": "sha512-q7OwXq6NTdcYIa+k58nEMV3j1euhDhGCs/VRw9ymx/PbH0jtIM2+VTgDE/BW3rbLkrBUXs5fzEKgic5oUciu7g==",
+              "version": "^4.4.8",
               "optional": true,
               "requires": {
                 "chownr": "^1.1.4",
@@ -12115,9 +12103,7 @@
           "optional": true
         },
         "tar": {
-          "version": "4.4.17",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.17.tgz",
-          "integrity": "sha512-q7OwXq6NTdcYIa+k58nEMV3j1euhDhGCs/VRw9ymx/PbH0jtIM2+VTgDE/BW3rbLkrBUXs5fzEKgic5oUciu7g=="
+          "version": "^4.4.8"
         },
         "util-deprecate": {
           "version": "1.0.2",
@@ -14218,9 +14204,7 @@
           }
         },
         "js-yaml": {
-          "version": "3.14.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "version": "^3.13.1",
           "requires": {
             "argparse": "^1.0.7",
             "esprima": "^4.0.0"
@@ -14594,15 +14578,13 @@
             "istanbul-lib-report": "^1.1.5",
             "istanbul-lib-source-maps": "^1.2.6",
             "istanbul-reports": "^1.5.1",
-            "js-yaml": "^3.7.0",
+            "js-yaml": "^3.13.1",
             "mkdirp": "^0.5.1",
             "once": "^1.4.0"
           },
           "dependencies": {
             "js-yaml": {
-              "version": "3.14.1",
-              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-              "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+              "version": "^3.13.1",
               "dev": true,
               "requires": {
                 "argparse": "^1.0.7",
@@ -14705,9 +14687,7 @@
           }
         },
         "mem": {
-          "version": "9.0.1",
-          "resolved": "https://registry.npmjs.org/mem/-/mem-9.0.1.tgz",
-          "integrity": "sha512-f4uEX3Ley9FZqcFIRSBr2q43x1bJQeDvsxgkSN/BPnA7jY9Aue4sBU2dsjmpDwiaY/QY1maNCeosbUHQWzzdQw==",
+          "version": ">=4.0.0",
           "requires": {
             "map-age-cleaner": "^0.1.3"
           }
@@ -14750,13 +14730,11 @@
           "requires": {
             "execa": "^1.0.0",
             "lcid": "^2.0.0",
-            "mem": "^4.0.0"
+            "mem": ">=4.0.0"
           },
           "dependencies": {
             "mem": {
-              "version": "9.0.1",
-              "resolved": "https://registry.npmjs.org/mem/-/mem-9.0.1.tgz",
-              "integrity": "sha512-f4uEX3Ley9FZqcFIRSBr2q43x1bJQeDvsxgkSN/BPnA7jY9Aue4sBU2dsjmpDwiaY/QY1maNCeosbUHQWzzdQw==",
+              "version": ">=4.0.0",
               "dev": true,
               "requires": {
                 "map-age-cleaner": "^0.1.3",
@@ -15807,9 +15785,7 @@
           }
         },
         "mem": {
-          "version": "9.0.1",
-          "resolved": "https://registry.npmjs.org/mem/-/mem-9.0.1.tgz",
-          "integrity": "sha512-f4uEX3Ley9FZqcFIRSBr2q43x1bJQeDvsxgkSN/BPnA7jY9Aue4sBU2dsjmpDwiaY/QY1maNCeosbUHQWzzdQw==",
+          "version": ">=4.0.0",
           "requires": {
             "map-age-cleaner": "^0.1.3"
           }
@@ -15852,13 +15828,11 @@
           "requires": {
             "execa": "^1.0.0",
             "lcid": "^2.0.0",
-            "mem": "^4.0.0"
+            "mem": ">=4.0.0"
           },
           "dependencies": {
             "mem": {
-              "version": "9.0.1",
-              "resolved": "https://registry.npmjs.org/mem/-/mem-9.0.1.tgz",
-              "integrity": "sha512-f4uEX3Ley9FZqcFIRSBr2q43x1bJQeDvsxgkSN/BPnA7jY9Aue4sBU2dsjmpDwiaY/QY1maNCeosbUHQWzzdQw==",
+              "version": ">=4.0.0",
               "dev": true,
               "requires": {
                 "map-age-cleaner": "^0.1.3",
@@ -16051,9 +16025,7 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "^3.13.1",
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -18035,7 +18007,7 @@
       "integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
       "dev": true,
       "requires": {
-        "fstream": "^1.0.0",
+        "fstream": ">=1.0.12",
         "glob": "^7.0.3",
         "graceful-fs": "^4.1.2",
         "mkdirp": "^0.5.0",
@@ -18045,14 +18017,12 @@
         "request": "^2.87.0",
         "rimraf": "2",
         "semver": "~5.3.0",
-        "tar": "^2.0.0",
+        "tar": "^4.4.8",
         "which": "1"
       },
       "dependencies": {
         "fstream": {
-          "version": "1.0.12",
-          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
-          "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+          "version": ">=1.0.12",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -18079,9 +18049,7 @@
           "dev": true
         },
         "tar": {
-          "version": "4.4.17",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.17.tgz",
-          "integrity": "sha512-q7OwXq6NTdcYIa+k58nEMV3j1euhDhGCs/VRw9ymx/PbH0jtIM2+VTgDE/BW3rbLkrBUXs5fzEKgic5oUciu7g==",
+          "version": "^4.4.8",
           "dev": true,
           "requires": {
             "chownr": "^1.1.4",
@@ -18094,9 +18062,7 @@
           },
           "dependencies": {
             "fstream": {
-              "version": "1.0.12",
-              "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
-              "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+              "version": ">=1.0.12",
               "requires": {
                 "graceful-fs": "^4.1.2",
                 "inherits": "~2.0.0",
@@ -19564,9 +19530,7 @@
           }
         },
         "mem": {
-          "version": "9.0.1",
-          "resolved": "https://registry.npmjs.org/mem/-/mem-9.0.1.tgz",
-          "integrity": "sha512-f4uEX3Ley9FZqcFIRSBr2q43x1bJQeDvsxgkSN/BPnA7jY9Aue4sBU2dsjmpDwiaY/QY1maNCeosbUHQWzzdQw==",
+          "version": ">=4.0.0",
           "requires": {
             "map-age-cleaner": "^0.1.3"
           }
@@ -19579,13 +19543,11 @@
           "requires": {
             "execa": "^1.0.0",
             "lcid": "^2.0.0",
-            "mem": "^4.0.0"
+            "mem": ">=4.0.0"
           },
           "dependencies": {
             "mem": {
-              "version": "9.0.1",
-              "resolved": "https://registry.npmjs.org/mem/-/mem-9.0.1.tgz",
-              "integrity": "sha512-f4uEX3Ley9FZqcFIRSBr2q43x1bJQeDvsxgkSN/BPnA7jY9Aue4sBU2dsjmpDwiaY/QY1maNCeosbUHQWzzdQw==",
+              "version": ">=4.0.0",
               "dev": true,
               "requires": {
                 "map-age-cleaner": "^0.1.3",
@@ -21432,7 +21394,7 @@
         "glob": "^7.0.0",
         "globule": "^1.0.0",
         "gonzales-pe-sl": "^4.2.3",
-        "js-yaml": "^3.5.4",
+        "js-yaml": "^3.13.1",
         "known-css-properties": "^0.3.0",
         "lodash.capitalize": "^4.1.0",
         "lodash.kebabcase": "^4.0.0",
@@ -21547,7 +21509,7 @@
             "inquirer": "^0.12.0",
             "is-my-json-valid": "^2.10.0",
             "is-resolvable": "^1.0.0",
-            "js-yaml": "^3.5.1",
+            "js-yaml": "^3.13.1",
             "json-stable-stringify": "^1.0.0",
             "levn": "^0.3.0",
             "lodash": "^4.0.0",
@@ -21558,7 +21520,7 @@
             "pluralize": "^1.2.1",
             "progress": "^1.1.8",
             "require-uncached": "^1.0.2",
-            "shelljs": "^0.6.0",
+            "shelljs": ">=0.8.3",
             "strip-json-comments": "~1.0.1",
             "table": "^3.7.8",
             "text-table": "~0.2.0",
@@ -21566,9 +21528,7 @@
           },
           "dependencies": {
             "js-yaml": {
-              "version": "3.14.1",
-              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-              "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+              "version": "^3.13.1",
               "dev": true,
               "requires": {
                 "argparse": "^1.0.7",
@@ -21576,9 +21536,7 @@
               }
             },
             "shelljs": {
-              "version": "0.8.4",
-              "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
-              "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
+              "version": ">=0.8.3",
               "dev": true,
               "requires": {
                 "glob": "^7.0.0",
@@ -21659,9 +21617,7 @@
           }
         },
         "js-yaml": {
-          "version": "3.14.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "version": "^3.13.1",
           "dev": true,
           "requires": {
             "argparse": "^1.0.7",
@@ -21718,9 +21674,7 @@
           }
         },
         "shelljs": {
-          "version": "0.8.4",
-          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
-          "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
+          "version": ">=0.8.3",
           "requires": {
             "glob": "^7.0.0",
             "interpret": "^1.0.0",
@@ -22506,14 +22460,12 @@
             "parseqs": "0.0.5",
             "parseuri": "0.0.5",
             "ws": "~3.3.1",
-            "xmlhttprequest-ssl": "~1.5.4",
+            "xmlhttprequest-ssl": ">=1.6.2",
             "yeast": "0.1.2"
           },
           "dependencies": {
             "xmlhttprequest-ssl": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz",
-              "integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==",
+              "version": ">=1.6.2",
               "dev": true
             }
           }
@@ -23371,9 +23323,7 @@
       },
       "dependencies": {
         "js-yaml": {
-          "version": "3.14.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "version": "^3.13.1",
           "optional": true,
           "requires": {
             "argparse": "^1.0.7",
@@ -25135,9 +25085,7 @@
           }
         },
         "mem": {
-          "version": "9.0.1",
-          "resolved": "https://registry.npmjs.org/mem/-/mem-9.0.1.tgz",
-          "integrity": "sha512-f4uEX3Ley9FZqcFIRSBr2q43x1bJQeDvsxgkSN/BPnA7jY9Aue4sBU2dsjmpDwiaY/QY1maNCeosbUHQWzzdQw==",
+          "version": ">=4.0.0",
           "requires": {
             "map-age-cleaner": "^0.1.3"
           }
@@ -25154,13 +25102,11 @@
           "requires": {
             "execa": "^0.7.0",
             "lcid": "^1.0.0",
-            "mem": "^1.1.0"
+            "mem": ">=4.0.0"
           },
           "dependencies": {
             "mem": {
-              "version": "9.0.1",
-              "resolved": "https://registry.npmjs.org/mem/-/mem-9.0.1.tgz",
-              "integrity": "sha512-f4uEX3Ley9FZqcFIRSBr2q43x1bJQeDvsxgkSN/BPnA7jY9Aue4sBU2dsjmpDwiaY/QY1maNCeosbUHQWzzdQw==",
+              "version": ">=4.0.0",
               "requires": {
                 "map-age-cleaner": "^0.1.3",
                 "mimic-fn": "^4.0.0"
@@ -25476,9 +25422,7 @@
           }
         },
         "mem": {
-          "version": "9.0.1",
-          "resolved": "https://registry.npmjs.org/mem/-/mem-9.0.1.tgz",
-          "integrity": "sha512-f4uEX3Ley9FZqcFIRSBr2q43x1bJQeDvsxgkSN/BPnA7jY9Aue4sBU2dsjmpDwiaY/QY1maNCeosbUHQWzzdQw==",
+          "version": ">=4.0.0",
           "requires": {
             "map-age-cleaner": "^0.1.3"
           }
@@ -25491,13 +25435,11 @@
           "requires": {
             "execa": "^1.0.0",
             "lcid": "^2.0.0",
-            "mem": "^4.0.0"
+            "mem": ">=4.0.0"
           },
           "dependencies": {
             "mem": {
-              "version": "9.0.1",
-              "resolved": "https://registry.npmjs.org/mem/-/mem-9.0.1.tgz",
-              "integrity": "sha512-f4uEX3Ley9FZqcFIRSBr2q43x1bJQeDvsxgkSN/BPnA7jY9Aue4sBU2dsjmpDwiaY/QY1maNCeosbUHQWzzdQw==",
+              "version": ">=4.0.0",
               "dev": true,
               "requires": {
                 "map-age-cleaner": "^0.1.3",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Data Hub Find Exporters",
   "main": "server.js",
   "engines": {
-    "node": "10.16.0",
-    "yarn": "1.16.0"
+    "node": "10.19.0",
+    "yarn": "1.21.1"
   },
   "jest": {
     "moduleNameMapper": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7105,7 +7105,7 @@ growly@^1.3.0:
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
-handlebars@>=4.0.14, handlebars@^4.0.3, handlebars@^4.1.2, handlebars@^4.7.6:
+handlebars@^4.0.3, handlebars@^4.1.2, handlebars@^4.7.6:
   version "4.7.7"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"
   integrity sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==
@@ -8901,7 +8901,7 @@ js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
-js-yaml@4.0.0, js-yaml@>=3.13.1, js-yaml@^3.13.0, js-yaml@^3.13.1, js-yaml@^3.4.6, js-yaml@^3.5.1, js-yaml@^3.5.4, js-yaml@^3.7.0:
+js-yaml@4.0.0, js-yaml@^3.13.0, js-yaml@^3.13.1, js-yaml@^3.4.6, js-yaml@^3.5.1, js-yaml@^3.5.4, js-yaml@^3.7.0:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
   integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
@@ -9467,7 +9467,7 @@ lodash.zip@^4.2.0:
   resolved "https://registry.yarnpkg.com/lodash.zip/-/lodash.zip-4.2.0.tgz#ec6662e4896408ed4ab6c542a3990b72cc080020"
   integrity sha1-7GZi5IlkCO1KtsVCo5kLcswIACA=
 
-lodash@4.17.15, lodash@>=4.17.13, lodash@>=4.17.21, lodash@^4, lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0, lodash@~4.17.10:
+lodash@>=4.17.21, lodash@^4, lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0, lodash@~4.17.10:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -15063,10 +15063,10 @@ xml@^1.0.0:
   resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
   integrity sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=
 
-xmlhttprequest-ssl@~1.5.4:
-  version "1.5.5"
-  resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz#c2876b06168aadc40e57d97e81191ac8f4398b3e"
-  integrity sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=
+xmlhttprequest-ssl@>=1.6.2, xmlhttprequest-ssl@~1.5.4:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz#91360c86b914e67f44dce769180027c0da618c67"
+  integrity sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==
 
 xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
This PR addresses the critical security vulnerability in the xmlhttprequest-ssl package, by making sure it's upgraded to a safe version in the yarn.lock file. In order to do this I have bumped the node version to `10.19.0` and yarn to `1.21.1`.