### PR TITLE
Fixed json schema security vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24185,11 +24185,6 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
-    "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
-    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -24247,6 +24242,13 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
         "verror": "1.10.0"
+      },
+      "dependencies": {
+        "json-schema": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+          "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
+        }
       }
     },
     "jsx-ast-utils": {

--- a/package.json
+++ b/package.json
@@ -181,6 +181,7 @@
     "set-value": "4.0.1",
     "nth-check": "2.0.1",
     "semver-regex": "3.1.3",
-    "jsonpointer": ">=5.0.0"
+    "jsonpointer": ">=5.0.0",
+    "json-schema": ">=0.4.0"
   }
 }


### PR DESCRIPTION
json-schema is vulnerable to Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution') below v0.4.0, so this PR fixes the version to >=0.4.0. 
